### PR TITLE
Centralize Prisma client and ensure graceful shutdown

### DIFF
--- a/src/modules/advertising/advertising.repository.ts
+++ b/src/modules/advertising/advertising.repository.ts
@@ -1,11 +1,11 @@
-import {PrismaClient, Advertising, UnitNew} from "@prisma/client";
+import { PrismaClient, Advertising, UnitNew } from "@prisma/client";
+import prisma from "@/prisma";
 
 export class AdvertisingRepository {
-    constructor(private prisma: PrismaClient = new PrismaClient()) {
-    }
+    constructor(private prismaClient: PrismaClient = prisma) {}
 
     async create(campaign: any, date: string): Promise<Advertising> {
-        return this.prisma.advertising.upsert({
+        return this.prismaClient.advertising.upsert({
             where: {
                 savedAt_campaignId: {
                     savedAt: new Date(date),
@@ -50,7 +50,7 @@ export class AdvertisingRepository {
     }
 
     async lastRow(): Promise<Advertising | null> {
-        return this.prisma.advertising.findFirst({
+        return this.prismaClient.advertising.findFirst({
             orderBy: {
                 savedAt: 'desc',
             },
@@ -58,7 +58,7 @@ export class AdvertisingRepository {
     }
 
     async getAdsAggByProductType(start: string, end: string) {
-        const totals = await this.prisma.advertising.groupBy({
+        const totals = await this.prismaClient.advertising.groupBy({
             by: [
                 "productId"
             ],

--- a/src/modules/unit/unit.repository.ts
+++ b/src/modules/unit/unit.repository.ts
@@ -1,12 +1,12 @@
-import {Prisma, PrismaClient, UnitNew} from '@prisma/client';
-import {UnitDto} from "@/modules/unit/dto/unit.dto";
+import { Prisma, PrismaClient, UnitNew } from '@prisma/client';
+import { UnitDto } from "@/modules/unit/dto/unit.dto";
+import prisma from "@/prisma";
 
 export class UnitRepository {
-    constructor(private prisma: PrismaClient = new PrismaClient()) {
-    }
+    constructor(private prismaClient: PrismaClient = prisma) {}
 
     async create(data: Omit<UnitDto, 'id'>): Promise<UnitNew> {
-        return this.prisma.unitNew.upsert({
+        return this.prismaClient.unitNew.upsert({
             where: {
                 postingNumber: data.postingNumber
             },
@@ -26,11 +26,11 @@ export class UnitRepository {
     }
 
     async rowsCount(): Promise<number> {
-        return this.prisma.unitNew.count();
+        return this.prismaClient.unitNew.count();
     }
 
     async notDeliveredUnits(): Promise<UnitNew[]> {
-        return this.prisma.unitNew.findMany({
+        return this.prismaClient.unitNew.findMany({
             where: {
                 statusOzon: {
                     notIn: ["cancelled", "delivered"],
@@ -40,7 +40,7 @@ export class UnitRepository {
     }
 
     async updatePostingStatus(status: string, postingNumber: string) {
-        await this.prisma.unitNew.update({
+        await this.prismaClient.unitNew.update({
             where: {
                 postingNumber
             },
@@ -51,7 +51,7 @@ export class UnitRepository {
     }
 
     async lastPostingDate() {
-        const unit = await this.prisma.unitNew.findFirst({
+        const unit = await this.prismaClient.unitNew.findFirst({
             orderBy: {
                 createdAt: "desc"
             },
@@ -61,7 +61,7 @@ export class UnitRepository {
     }
 
     async lastTransactionDate() {
-        const unit = await this.prisma.unitNew.findFirst({
+        const unit = await this.prismaClient.unitNew.findFirst({
             where: {
                 lastOperationDate: {
                     not: null,
@@ -76,7 +76,7 @@ export class UnitRepository {
     }
 
     async getUnitByPostingNumber(postingNumber: string): Promise<UnitNew | null> {
-        return this.prisma.unitNew.findFirst({
+        return this.prismaClient.unitNew.findFirst({
             where: {
                 OR: [
                     {postingNumber: postingNumber},
@@ -87,7 +87,7 @@ export class UnitRepository {
     }
 
     async getAll(): Promise<UnitNew[]> {
-        return this.prisma.unitNew.findMany({
+        return this.prismaClient.unitNew.findMany({
             orderBy: {
                 createdAt: 'desc',
             }
@@ -95,7 +95,7 @@ export class UnitRepository {
     }
 
     async getUnitsRevenueBySku(start: string, end: string) {
-        const orders = await this.prisma.unitNew.groupBy({
+        const orders = await this.prismaClient.unitNew.groupBy({
             by: [
                 "sku",
             ],

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function shutdown() {
+  await prisma.$disconnect();
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add a shared `PrismaClient` singleton with signal handlers
- update advertising and unit repositories to use the singleton instance

## Testing
- `npm test` *(fails: Missing environment variable OZON_PERFORMANCE_CLIENT_ID)*

------
https://chatgpt.com/codex/tasks/task_e_68aad8434c34832a9f26cbd30ac75650