### PR TITLE
feat: add error handling middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import advertisingRouter from "@/modules/advertising/advertising.route";
 import analyticsRouter from "@/modules/analytics/analytics.route";
 import cors from "cors";
 import { PORT, CORS_ORIGIN } from '@/config';
+import errorHandler from "@/middleware/error.middleware";
 
 const app = express();
 
@@ -15,6 +16,8 @@ app.use(cors({
 app.use('/unit', unitRouter);
 app.use('/ads', advertisingRouter);
 app.use("/analytics", analyticsRouter);
+
+app.use(errorHandler);
 
 app.listen(PORT, () => {
     console.log(`🚀 Server is running at http://localhost:${PORT}`);

--- a/src/middleware/error.middleware.ts
+++ b/src/middleware/error.middleware.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+import { logger } from '@/utils/logger';
+
+export default function errorHandler(
+    err: any,
+    req: Request,
+    res: Response,
+    next: NextFunction
+) {
+    logger.error(err);
+    const status = err.status || 500;
+    res.status(status).json({ error: err.message });
+}


### PR DESCRIPTION
## Summary
- add centralized error handling middleware using logger
- register error handler in Express app

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aadbd011c0832ab0c93266d7fdd777