### PR TITLE
Add async handler utility and simplify controllers

### DIFF
--- a/src/modules/advertising/advertising.controller.ts
+++ b/src/modules/advertising/advertising.controller.ts
@@ -3,13 +3,8 @@ import {advertisingService} from "./advertising.service";
 
 export const advertisingController = {
     async sync(req: Request, res: Response) {
-        try {
-            await advertisingService.sync();
+        await advertisingService.sync();
 
-            res.json({data: 'OK'});
-        } catch (err) {
-            console.error("[analyticsController] Ошибка:", err);
-            res.status(500).json({error: err});
-        }
+        res.json({data: 'OK'});
     },
 };

--- a/src/modules/advertising/advertising.route.ts
+++ b/src/modules/advertising/advertising.route.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { advertisingController } from '@/modules/advertising/advertising.controller';
+import asyncHandler from '@/utils/asyncHandler';
 
 const router = Router();
-router.get('/sync', advertisingController.sync);
+router.get('/sync', asyncHandler(advertisingController.sync));
 
 export default router;

--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -3,13 +3,8 @@ import {analyticsService} from "@/modules/analytics/analytics.service";
 
 export const analyticsController = {
     async getDrrByDate(req: Request, res: Response) {
-        try {
-            const data = await analyticsService.getDrrByDate('2025-07-02');
+        const data = await analyticsService.getDrrByDate('2025-07-02');
 
-            res.json({data});
-        } catch (err) {
-            console.error("[analyticsController] Ошибка:", err);
-            res.status(500).json({error: err});
-        }
+        res.json({data});
     },
 };

--- a/src/modules/analytics/analytics.route.ts
+++ b/src/modules/analytics/analytics.route.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import { analyticsController } from '@/modules/analytics/analytics.controller';
+import asyncHandler from '@/utils/asyncHandler';
 
 const router = Router();
-router.get('/drr-by-date', analyticsController.getDrrByDate);
+router.get('/drr-by-date', asyncHandler(analyticsController.getDrrByDate));
 
 export default router;

--- a/src/modules/unit/unit.controller.ts
+++ b/src/modules/unit/unit.controller.ts
@@ -3,54 +3,18 @@ import {unitService} from "./unit.service";
 
 export const unitController = {
     async sync(req: Request, res: Response): Promise<any> {
-        try {
-            await unitService.sync();
+        await unitService.sync();
 
-            console.log('121');
+        console.log('121');
 
-            const data = await unitService.getAll();
+        const data = await unitService.getAll();
 
-            res.json(data);
-        } catch (error: any) {
-            let message = "Неизвестная ошибка";
-
-            // Если это ошибка axios
-            if (error.isAxiosError) {
-                message =
-                    error.response?.data?.message ||
-                    error.message ||
-                    "Ошибка при запросе";
-            } else if (error instanceof Error) {
-                message = error.message;
-            }
-
-            console.error("[unitController] Ошибка:", message);
-
-            return res.status(500).json({error: message});
-        }
+        res.json(data);
     },
 
     async getAll(req: Request, res: Response): Promise<any> {
-        try {
-            const data = await unitService.getAll();
+        const data = await unitService.getAll();
 
-            res.json(data);
-        } catch (error: any) {
-            let message = "Неизвестная ошибка";
-
-            // Если это ошибка axios
-            if (error.isAxiosError) {
-                message =
-                    error.response?.data?.message ||
-                    error.message ||
-                    "Ошибка при запросе";
-            } else if (error instanceof Error) {
-                message = error.message;
-            }
-
-            console.error("[unitController] Ошибка:", message);
-
-            return res.status(500).json({error: message});
-        }
+        res.json(data);
     },
 };

--- a/src/modules/unit/unit.route.ts
+++ b/src/modules/unit/unit.route.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
 import { unitController } from '@/modules/unit/unit.controller';
+import asyncHandler from '@/utils/asyncHandler';
 
 const router = Router();
 
-router.get('/sync', unitController.sync);
-router.get('/all', unitController.getAll);
+router.get('/sync', asyncHandler(unitController.sync));
+router.get('/all', asyncHandler(unitController.getAll));
 
 export default router;

--- a/src/utils/asyncHandler.ts
+++ b/src/utils/asyncHandler.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Wraps an async route handler and forwards errors to the next middleware.
+ */
+const asyncHandler = (
+    fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+): RequestHandler => {
+    return (req, res, next) => {
+        Promise.resolve(fn(req, res, next)).catch(next);
+    };
+};
+
+export default asyncHandler;
+


### PR DESCRIPTION
## Summary
- add async handler to propagate route errors to Express
- wrap module routes with async handler
- simplify controllers by removing local try/catch blocks

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aadcf436dc832aa48a33132f544bc3