### PR TITLE
Add DRR analytics endpoint

### DIFF
--- a/src/modules/analytics/controller/controller.ts
+++ b/src/modules/analytics/controller/controller.ts
@@ -1,6 +1,7 @@
-import {Request, Response} from "express";
+import { Request, Response } from "express";
 import container from '@/infrastructure/di/container';
-import {AnalyticsService} from "@/modules/analytics/service/service";
+import { AnalyticsService } from "@/modules/analytics/service/service";
+import { DrrRequestDto } from "@/modules/analytics/dto/drr.dto";
 
 const analyticsService = container.resolve(AnalyticsService);
 
@@ -9,5 +10,18 @@ export const analyticsController = {
         const data = await analyticsService.getDrrByDate('2025-07-02');
 
         res.json({data});
+    },
+
+    async getDrr(req: Request, res: Response) {
+        const { dateFrom, dateTo, sku } = req.query;
+        const query: DrrRequestDto = {
+            dateFrom: String(dateFrom),
+            dateTo: String(dateTo),
+            sku: Array.isArray(sku) ? sku.map(String) : typeof sku === 'string' ? [sku] : [],
+        };
+
+        const data = await analyticsService.getDrr(query);
+
+        res.json({ data });
     },
 };

--- a/src/modules/analytics/dto/drr.dto.ts
+++ b/src/modules/analytics/dto/drr.dto.ts
@@ -1,0 +1,22 @@
+export interface DrrRequestDto {
+    dateFrom: string;
+    dateTo: string;
+    sku: string[];
+}
+
+export interface DrrResponseDto {
+    orders: {
+        items: {
+            sku: string;
+            item: number;
+        }[];
+        totals: number;
+    };
+    ads: {
+        items: {
+            productId: string;
+            moneySpent: number;
+        }[];
+        totals: number;
+    };
+}

--- a/src/modules/analytics/route.ts
+++ b/src/modules/analytics/route.ts
@@ -3,6 +3,7 @@ import { analyticsController } from '@/modules/analytics/controller/controller';
 import asyncHandler from '@/shared/utils/asyncHandler';
 
 const router = Router();
+router.get('/drr', asyncHandler(analyticsController.getDrr));
 router.get('/drr-by-date', asyncHandler(analyticsController.getDrrByDate));
 
 export default router;

--- a/src/modules/analytics/service/service.ts
+++ b/src/modules/analytics/service/service.ts
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { UnitRepository } from '@/modules/unit/repository/repository';
 import { AdvertisingRepository } from '@/modules/advertising/repository/repository';
 import { logger } from '@/shared/logger';
+import { DrrRequestDto, DrrResponseDto } from "@/modules/analytics/dto/drr.dto";
 
 export class AnalyticsService {
     constructor(
@@ -27,5 +28,30 @@ export class AnalyticsService {
             orders,
             ads,
         }
+    }
+
+    async getDrr({ dateFrom, dateTo, sku }: DrrRequestDto): Promise<DrrResponseDto> {
+        logger.info({ dateFrom, dateTo, sku }, 'Получение DRR');
+
+        const ads = await this.adsRepo.getAdsAggByProductType(
+            dayjs(dateFrom).format('YYYY-MM-DD[T]00:00:00[Z]'),
+            dayjs(dateTo).format('YYYY-MM-DD[T]23:59:59[Z]'),
+        );
+
+        const orders = await this.unitRepo.getUnitsRevenueBySku(
+            dayjs(dateFrom).subtract(1, 'day').format('YYYY-MM-DD[T]20:59:59[Z]'),
+            dayjs(dateTo).format('YYYY-MM-DD[T]21:00:00[Z]'),
+        );
+
+        const filteredAdsItems = sku.length ? ads.items.filter((i: any) => sku.includes(i.productId)) : ads.items;
+        const filteredOrdersItems = sku.length ? orders.items.filter((i: any) => sku.includes(i.sku)) : orders.items;
+
+        const adsTotals = sku.length ? filteredAdsItems.reduce((acc: number, i: any) => acc + i.moneySpent, 0) : ads.totals;
+        const ordersTotals = sku.length ? filteredOrdersItems.reduce((acc: number, i: any) => acc + i.item, 0) : orders.totals;
+
+        return {
+            ads: { items: filteredAdsItems, totals: adsTotals },
+            orders: { items: filteredOrdersItems, totals: ordersTotals },
+        };
     }
 }


### PR DESCRIPTION
## Summary
- define request and response DTOs for DRR analytics
- add /drr route and controller to parse query parameters
- extend analytics service to handle date range and SKU filtering

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68aafc2843d8832aabd466bb768c4df6