### PR TITLE
Refactor DRR analytics to use generic ad items

### DIFF
--- a/src/modules/analytics/controller/controller.ts
+++ b/src/modules/analytics/controller/controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import container from '@/infrastructure/di/container';
 import { AnalyticsService } from "@/modules/analytics/service/service";
-import { DrrRequestDto } from "@/modules/analytics/dto/drr.dto";
+import { DrrRequestDto, DrrResponseDto } from "@/modules/analytics/dto/drr.dto";
 
 const analyticsService = container.resolve(AnalyticsService);
 
@@ -14,7 +14,7 @@ export const analyticsController = {
             sku: Array.isArray(sku) ? sku.map(String) : typeof sku === 'string' ? [sku] : [],
         };
 
-        const data = await analyticsService.getDrr(query);
+        const data: DrrResponseDto = await analyticsService.getDrr(query);
 
         res.json({ data });
     },

--- a/src/modules/analytics/dto/drr.dto.ts
+++ b/src/modules/analytics/dto/drr.dto.ts
@@ -6,12 +6,11 @@ export interface DrrProductDto {
     sku: string;
     orders: {
         count: number;
-        sum: number;
+        money: number;
     };
     ads: {
-        cpo: number;
-        other: number;
-        total: number;
+        items: { type: string; money: number }[];
+        totals: number;
     };
     drr: number;
 }
@@ -19,12 +18,11 @@ export interface DrrProductDto {
 export interface DrrTotalsDto {
     orders: {
         count: number;
-        sum: number;
+        money: number;
     };
     ads: {
-        cpo: number;
-        other: number;
-        total: number;
+        items: { type: string; money: number }[];
+        totals: number;
     };
     drr: number;
 }


### PR DESCRIPTION
## Summary
- rename DRR DTO fields to use `orders.money`
- represent ads as typed items with totals
- aggregate ad spend by type and compute totals in service
- type controller responses with new DTO

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab0466b1d0832abb44212bd608c9c9