### PR TITLE
feat: add margin analytics endpoint

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,29 @@
+# Analytics API
+
+## GET /analytics/margin
+
+Retrieves margin statistics grouped by month and SKU.
+
+### Query parameters
+- `from` – start date (YYYY-MM-DD)
+- `to` – end date (YYYY-MM-DD)
+- `sku` – optional SKU filter. May be repeated.
+
+### Response
+```
+[
+  {
+    "month": "2024-01",
+    "items": [
+      {
+        "sku": "123",
+        "statuses": { "delivered": 10, "cancelled": 2 },
+        "totalServices": 100,
+        "totalCostPrice": 200,
+        "margin": 50
+      }
+    ]
+  }
+]
+```
+Each month's margin value is reduced by the advertising spend for that SKU and month.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/src/modules/analytics/controller/__tests__/controller.test.ts
+++ b/src/modules/analytics/controller/__tests__/controller.test.ts
@@ -1,0 +1,27 @@
+import { AnalyticsService } from '@/modules/analytics/service/service';
+
+describe('analyticsController.getMargin', () => {
+    beforeAll(() => {
+        process.env.OZON_PERFORMANCE_CLIENT_ID = '1';
+        process.env.OZON_PERFORMANCE_CLIENT_SECRET = '1';
+        process.env.OZON_SELLER_CLIENT_ID = '1';
+        process.env.OZON_SELLER_API_KEY = '1';
+        process.env.CORS_ORIGIN = '*';
+        process.env.PORT = '3000';
+    });
+
+    it('parses query and returns service data', async () => {
+        const { analyticsController } = await import('@/modules/analytics/controller/controller');
+        const container = (await import('@/infrastructure/di/container')).default;
+        const service = container.resolve(AnalyticsService);
+        const mock = jest.spyOn(service, 'getMargin').mockResolvedValue([{ month: '2024-01', items: [] }]);
+
+        const req: any = { query: { from: '2024-01-01', to: '2024-01-31', sku: '1' } };
+        const res: any = { json: jest.fn() };
+
+        await analyticsController.getMargin(req, res);
+
+        expect(mock).toHaveBeenCalledWith({ from: '2024-01-01', to: '2024-01-31', sku: ['1'] });
+        expect(res.json).toHaveBeenCalledWith({ data: [{ month: '2024-01', items: [] }] });
+    });
+});

--- a/src/modules/analytics/controller/controller.ts
+++ b/src/modules/analytics/controller/controller.ts
@@ -3,6 +3,7 @@ import container from '@/infrastructure/di/container';
 import { AnalyticsService } from "@/modules/analytics/service/service";
 import { DrrRequestDto, DrrResponseDto } from "@/modules/analytics/dto/drr.dto";
 import { BuyoutRequestDto, BuyoutMonthDto } from "@/modules/analytics/dto/buyout.dto";
+import { MarginRequestDto, MarginMonthDto } from "@/modules/analytics/dto/margin.dto";
 import dayjs from "dayjs";
 
 const analyticsService = container.resolve(AnalyticsService);
@@ -30,6 +31,19 @@ export const analyticsController = {
         };
 
         const data: BuyoutMonthDto[] = await analyticsService.getBuyout(query);
+
+        res.json({ data });
+    },
+    async getMargin(req: Request, res: Response) {
+        const { from, to, sku } = req.query;
+
+        const query: MarginRequestDto = {
+            from: String(from),
+            to: String(to),
+            sku: Array.isArray(sku) ? sku.map(String) : typeof sku === 'string' ? [sku] : [],
+        };
+
+        const data: MarginMonthDto[] = await analyticsService.getMargin(query);
 
         res.json({ data });
     },

--- a/src/modules/analytics/dto/margin.dto.ts
+++ b/src/modules/analytics/dto/margin.dto.ts
@@ -1,0 +1,18 @@
+export interface MarginRequestDto {
+    from: string;
+    to: string;
+    sku: string[];
+}
+
+export interface MarginItemDto {
+    sku: string;
+    statuses: Record<string, number>;
+    totalServices: number;
+    totalCostPrice: number;
+    margin: number;
+}
+
+export interface MarginMonthDto {
+    month: string;
+    items: MarginItemDto[];
+}

--- a/src/modules/analytics/route.ts
+++ b/src/modules/analytics/route.ts
@@ -5,5 +5,6 @@ import asyncHandler from '@/shared/utils/asyncHandler';
 const router = Router();
 router.get('/drr', asyncHandler(analyticsController.getDrr));
 router.get('/buyout', asyncHandler(analyticsController.getBuyout));
+router.get('/margin', asyncHandler(analyticsController.getMargin));
 
 export default router;

--- a/src/modules/analytics/service/__tests__/service.test.ts
+++ b/src/modules/analytics/service/__tests__/service.test.ts
@@ -1,0 +1,71 @@
+import { AnalyticsService } from '@/modules/analytics/service/service';
+import { UnitRepository } from '@/modules/unit/repository/repository';
+import { AdvertisingRepository } from '@/modules/advertising/repository/repository';
+
+describe('AnalyticsService.getMargin', () => {
+    beforeAll(() => {
+        // @ts-ignore
+        global.logger = { info: jest.fn() };
+    });
+
+    it('aggregates margins by month and sku and subtracts ad spend', async () => {
+        const unitRepo = {
+            getEconomyBySku: jest.fn().mockResolvedValue([
+                { createdAt: new Date('2024-01-15'), sku: '1', statusOzon: 'delivered', margin: 100, costPrice: 50, totalServices: 10 },
+                { createdAt: new Date('2024-01-20'), sku: '1', statusOzon: 'cancelled', margin: 0, costPrice: 0, totalServices: 0 },
+                { createdAt: new Date('2024-02-05'), sku: '1', statusOzon: 'delivered', margin: 200, costPrice: 100, totalServices: 20 },
+                { createdAt: new Date('2024-02-10'), sku: '2', statusOzon: 'delivered', margin: 300, costPrice: 150, totalServices: 30 },
+            ]),
+        } as unknown as UnitRepository;
+
+        const adsRepo = {
+            getAdsAggByProductType: jest.fn((start: string) => {
+                if (start.startsWith('2024-01')) {
+                    return Promise.resolve({ items: [{ productId: '1', type: 't', moneySpent: 30 }], totals: 30 });
+                }
+                return Promise.resolve({ items: [
+                    { productId: '1', type: 't', moneySpent: 50 },
+                    { productId: '2', type: 't', moneySpent: 70 },
+                ], totals: 120 });
+            }),
+        } as unknown as AdvertisingRepository;
+
+        const service = new AnalyticsService(unitRepo, adsRepo);
+
+        const data = await service.getMargin({ from: '2024-01-01', to: '2024-02-29', sku: [] });
+
+        expect(data).toEqual([
+            {
+                month: '2024-01',
+                items: [
+                    {
+                        sku: '1',
+                        statuses: { delivered: 1, cancelled: 1 },
+                        totalServices: 10,
+                        totalCostPrice: 50,
+                        margin: 70,
+                    },
+                ],
+            },
+            {
+                month: '2024-02',
+                items: [
+                    {
+                        sku: '1',
+                        statuses: { delivered: 1 },
+                        totalServices: 20,
+                        totalCostPrice: 100,
+                        margin: 150,
+                    },
+                    {
+                        sku: '2',
+                        statuses: { delivered: 1 },
+                        totalServices: 30,
+                        totalCostPrice: 150,
+                        margin: 230,
+                    },
+                ],
+            },
+        ]);
+    });
+});

--- a/src/modules/analytics/service/service.ts
+++ b/src/modules/analytics/service/service.ts
@@ -4,6 +4,8 @@ import {AdvertisingRepository} from '@/modules/advertising/repository/repository
 import {DrrRequestDto, DrrResponseDto} from "@/modules/analytics/dto/drr.dto";
 import {AdItem, OrderItem} from "@/modules/analytics/dto/items.dto";
 import {BuyoutRequestDto, BuyoutItemDto, BuyoutMonthDto} from "@/modules/analytics/dto/buyout.dto";
+import {MarginRequestDto, MarginItemDto, MarginMonthDto} from "@/modules/analytics/dto/margin.dto";
+import {logger} from '@/shared/logger';
 
 export class AnalyticsService {
     constructor(
@@ -122,6 +124,71 @@ export class AnalyticsService {
                 const delivered = data.statuses['delivered'] || 0;
                 const buyout = data.total ? delivered / data.total : 0;
                 items.push({ sku: id, statuses: data.statuses, buyout });
+            });
+            result.push({ month, items });
+        });
+
+        return result;
+    }
+
+    async getMargin({ from, to, sku }: MarginRequestDto): Promise<MarginMonthDto[]> {
+        logger.info({from, to, sku}, 'Получение маржи');
+        const units = await this.unitRepo.getEconomyBySku(
+            dayjs(from).format('YYYY-MM-DD[T]00:00:00[Z]'),
+            dayjs(to).format('YYYY-MM-DD[T]23:59:59[Z]'),
+        );
+
+        const filtered = sku.length ? units.filter((u) => sku.includes(u.sku)) : units;
+
+        const grouped = new Map<string, Map<string, { statuses: Record<string, number>; totalServices: number; totalCostPrice: number; margin: number }>>();
+
+        filtered.forEach((u) => {
+            const month = dayjs(u.createdAt).format('YYYY-MM');
+            if (!grouped.has(month)) {
+                grouped.set(month, new Map());
+            }
+            const skuMap = grouped.get(month)!;
+            if (!skuMap.has(u.sku)) {
+                skuMap.set(u.sku, { statuses: {}, totalServices: 0, totalCostPrice: 0, margin: 0 });
+            }
+            const data = skuMap.get(u.sku)!;
+            data.statuses[u.statusOzon] = (data.statuses[u.statusOzon] || 0) + 1;
+            data.totalServices += u.totalServices;
+            data.totalCostPrice += u.costPrice;
+            data.margin += u.margin;
+        });
+
+        const months = Array.from(grouped.keys());
+
+        await Promise.all(months.map(async (m) => {
+            const start = dayjs(m).startOf('month').format('YYYY-MM-DD[T]00:00:00[Z]');
+            const end = dayjs(m).endOf('month').format('YYYY-MM-DD[T]23:59:59[Z]');
+            const ads = await this.adsRepo.getAdsAggByProductType(start, end);
+            const adMap = new Map<string, number>();
+            const adsItems = sku.length ? ads.items.filter((a: AdItem) => sku.includes(a.productId)) : ads.items;
+            adsItems.forEach((a: AdItem) => {
+                adMap.set(a.productId, (adMap.get(a.productId) || 0) + a.moneySpent);
+            });
+
+            const skuMap = grouped.get(m)!;
+            skuMap.forEach((data, id) => {
+                const spend = adMap.get(id) || 0;
+                data.margin -= spend;
+            });
+        }));
+
+        const result: MarginMonthDto[] = [];
+
+        grouped.forEach((skuMap, month) => {
+            const items: MarginItemDto[] = [];
+            skuMap.forEach((data, id) => {
+                items.push({
+                    sku: id,
+                    statuses: data.statuses,
+                    totalServices: data.totalServices,
+                    totalCostPrice: data.totalCostPrice,
+                    margin: data.margin,
+                });
             });
             result.push({ month, items });
         });

--- a/src/modules/unit/repository/repository.ts
+++ b/src/modules/unit/repository/repository.ts
@@ -158,4 +158,32 @@ export class UnitRepository {
             status: u.statusOzon,
         }));
     }
+
+    async getEconomyBySku(start: string, end: string): Promise<{ createdAt: Date; sku: string; statusOzon: string; margin: number; costPrice: number; totalServices: number }[]> {
+        const units = await this.prismaClient.unitNew.findMany({
+            where: {
+                createdAt: {
+                    gte: start,
+                    lte: end,
+                },
+            },
+            select: {
+                createdAt: true,
+                sku: true,
+                statusOzon: true,
+                margin: true,
+                costPrice: true,
+                totalServices: true,
+            },
+        });
+
+        return units.map((u) => ({
+            createdAt: u.createdAt,
+            sku: u.sku,
+            statusOzon: u.statusOzon,
+            margin: Number(u.margin),
+            costPrice: Number(u.costPrice),
+            totalServices: Number(u.totalServices),
+        }));
+    }
 }


### PR DESCRIPTION
## Summary
- add DTOs and margin analytics service
- expose /analytics/margin endpoint
- document API and add tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab0e19dfdc832a96db81cac23f1b68