### PR TITLE
feat: add basic telegram bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "nodemon",
     "build": "tsc",
     "start": "node dist/index.js",
-    "deploy": "gh-pages -d ./"
+    "deploy": "gh-pages -d ./",
+    "bot": "ts-node src/bot.ts"
   },
   "_moduleAliases": {
     "@": "dist"

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+const token = process.env.BOT_TOKEN!;
+const apiUrl = `https://api.telegram.org/bot${token}`;
+
+let offset = 0;
+
+async function poll() {
+    try {
+        const { data } = await axios.get(`${apiUrl}/getUpdates`, {
+            params: { timeout: 30, offset }
+        });
+
+        for (const update of data.result) {
+            offset = update.update_id + 1;
+            const message = update.message;
+            if (!message) continue;
+
+            const chatId = message.chat.id;
+            const text = message.text;
+
+            if (text === '/start') {
+                await axios.post(`${apiUrl}/sendMessage`, {
+                    chat_id: chatId,
+                    text: 'Нажмите кнопку, чтобы получить дрр',
+                    reply_markup: {
+                        keyboard: [[{ text: 'Получить дрр' }]],
+                        resize_keyboard: true
+                    }
+                });
+            } else if (text === 'Получить дрр') {
+                await axios.post(`${apiUrl}/sendMessage`, {
+                    chat_id: chatId,
+                    text: 'дрр'
+                });
+            }
+        }
+    } catch (err) {
+        console.error(err);
+    } finally {
+        setTimeout(poll, 1000);
+    }
+}
+
+poll();


### PR DESCRIPTION
## Summary
- add Telegram bot that replies "дрр" when button is pressed
- expose `bot` npm script for running the bot

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab538fd4a4832abf5a29a030c92724