### PR TITLE
Refactor bot with typing and currency formatting

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,39 +1,45 @@
-import {Telegraf, Markup} from 'telegraf';
-import {BOT_TOKEN} from '@/config';
-import container from "@/infrastructure/di/container";
-import {AnalyticsService} from "@/modules/analytics/service/service";
-import dayjs from "dayjs"; // или process.env.BOT_TOKEN
+import { Telegraf, Markup, Context } from 'telegraf';
+import { BOT_TOKEN } from '@/config';
+import container from '@/infrastructure/di/container';
+import { AnalyticsService } from '@/modules/analytics/service/service';
+import { DrrProductDto, DrrResponseDto } from '@/modules/analytics/dto/drr.dto';
+import dayjs from 'dayjs'; // или process.env.BOT_TOKEN
 
 if (!BOT_TOKEN) {
-    throw new Error('BOT_TOKEN не задан');
+  throw new Error('BOT_TOKEN не задан');
 }
 
-function formatDrrMessage(data: any) {
-    const {products, totals} = data;
+const formatCurrency = (value: number): string =>
+  new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 0,
+  }).format(value);
 
-    let text = '📊 Отчёт по DRR\n\n';
+function formatDrrMessage({ products, totals }: DrrResponseDto): string {
+  let text = '📊 Отчёт по DRR\n\n';
 
-    // по каждому товару
-    products.forEach((p: any) => {
-        text += `👜 SKU: ${p.sku}\n`;
-        text += `   • Заказы: ${p.orders.count} шт. на ${p.orders.money} ₽\n`;
-        text += `   • Реклама: ${p.ads.totals} ₽\n`;
+  // по каждому товару
+  products.forEach((p: DrrProductDto) => {
+    text += `👜 SKU: ${p.sku}\n`;
+    text += `   • Заказы: ${p.orders.count} шт. на ${formatCurrency(p.orders.money)}\n`;
+    text += `   • Реклама: ${formatCurrency(p.ads.totals)}\n`;
 
-        // по типам рекламы
-        p.ads.items.forEach((item: any) => {
-            text += `      - ${item.type}: ${item.money} ₽\n`;
-        });
-
-        text += `   • DRR: ${p.drr}%\n\n`;
+    // по типам рекламы
+    p.ads.items.forEach((item) => {
+      text += `      - ${item.type}: ${formatCurrency(item.money)}\n`;
     });
 
-    // блок тоталов
-    text += `💡 Итого по всем товарам:\n`;
-    text += `   • Заказы: ${totals.orders.count} шт. на ${totals.orders.money} ₽\n`;
-    text += `   • Реклама: ${totals.ads.totals} ₽\n`;
-    text += `   • DRR: ${totals.drr}%`;
+    text += `   • DRR: ${p.drr}%\n\n`;
+  });
 
-    return text;
+  // блок тоталов
+  text += `💡 Итого по всем товарам:\n`;
+  text += `   • Заказы: ${totals.orders.count} шт. на ${formatCurrency(totals.orders.money)}\n`;
+  text += `   • Реклама: ${formatCurrency(totals.ads.totals)}\n`;
+  text += `   • DRR: ${totals.drr}%`;
+
+  return text;
 }
 
 const analyticsService = container.resolve(AnalyticsService);
@@ -44,11 +50,11 @@ const mainKb = Markup.keyboard([
     ['📊 Получить DRR сумок', '📊 Получить DRR шапок']
 ]).resize();
 
-bot.start(async (ctx) => {
-    await ctx.reply('Привет! Нажми нужную кнопку ниже:', mainKb);
+bot.start(async (ctx: Context) => {
+  await ctx.reply('Привет! Нажми нужную кнопку ниже:', mainKb);
 });
 
-bot.hears('📊 Получить DRR сумок', async (ctx) => {
+bot.hears('📊 Получить DRR сумок', async (ctx: Context) => {
     const result = await analyticsService.getDrr({
         date: dayjs().subtract(2, 'day').format('YYYY-MM-DD'),
         sku: ['1828048543', '1828048513', '1828048540'],
@@ -59,7 +65,7 @@ bot.hears('📊 Получить DRR сумок', async (ctx) => {
     await ctx.reply(msg);
 });
 
-bot.hears('📊 Получить DRR шапок', async (ctx) => {
+bot.hears('📊 Получить DRR шапок', async (ctx: Context) => {
     const result = await analyticsService.getDrr({
         date: dayjs().format('YYYY-MM-DD'),
         sku: ['2586085325', '2586059276', '1763835247'],
@@ -70,7 +76,10 @@ bot.hears('📊 Получить DRR шапок', async (ctx) => {
     await ctx.reply(msg);
 });
 
-bot.launch().then(() => console.log('Bot started'));
+bot
+  .launch()
+  .then(() => console.log('Bot started'))
+  .catch((err: unknown) => console.error('Bot launch failed', err));
 
 process.once('SIGINT', () => bot.stop('SIGINT'));
 process.once('SIGTERM', () => bot.stop('SIGTERM'));


### PR DESCRIPTION
## Summary
- type bot context and analytics response
- add currency formatter for DRR report values
- handle bot launch errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d676be0832aa47ac286e5d3dc64