### PR TITLE
chore: remove deprecated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,31 +33,15 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "@adminjs/express": "^6.1.1",
-    "@adminjs/prisma": "^5.0.4",
     "@prisma/client": "^6.14.0",
-    "@types/papaparse": "^5.3.16",
-    "adminjs": "^7.8.17",
     "axios": "^1.10.0",
-    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
-    "csv-parse": "^6.1.0",
-    "currency.js": "^2.0.4",
-    "date-fns": "^4.1.0",
-    "date-fns-tz": "^3.2.0",
     "dayjs": "^1.11.13",
     "decimal.js": "^10.6.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "express-session": "^1.18.2",
-    "json2csv": "^6.0.0-alpha.2",
-    "module-alias": "^2.2.3",
-    "papaparse": "^5.5.3",
     "pino": "^9.7.0",
     "pino-pretty": "^13.0.0",
-    "telegraf": "^4.16.3",
-    "twilio": "^5.8.0",
-    "xlsx": "^0.18.5",
-    "zod": "^4.0.10"
+    "telegraf": "^4.16.3"
   }
 }


### PR DESCRIPTION
## Summary
- remove unused packages from dependencies

## Testing
- `npm uninstall @adminjs/express @adminjs/prisma @types/papaparse adminjs bcrypt csv-parse currency.js date-fns date-fns-tz express-session json2csv module-alias papaparse twilio xlsx zod --no-progress --force` *(fails: ENOTEMPTY rename 'wrap-ansi')*
- `npm install --no-progress` *(fails: 403 Forbidden @prisma/client)*
- `npm run build` *(fails: missing modules since install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5d68f668832aa9db15022b727db1