### PR TITLE
feat: include order totals in buyout analytics

### DIFF
--- a/src/modules/analytics/dto/buyout.dto.ts
+++ b/src/modules/analytics/dto/buyout.dto.ts
@@ -7,6 +7,7 @@ export interface BuyoutRequestDto {
 export interface BuyoutItemDto {
     sku: string;
     statuses: Record<string, number>;
+    total: number;
     buyout: number;
 }
 

--- a/src/modules/analytics/service/service.ts
+++ b/src/modules/analytics/service/service.ts
@@ -123,7 +123,7 @@ export class AnalyticsService {
             skuMap.forEach((data, id) => {
                 const delivered = data.statuses['Доставлен'] || 0;
                 const buyout = Math.floor((data.total ? delivered / data.total : 0) * 100);
-                items.push({ sku: id, statuses: data.statuses, buyout });
+                items.push({ sku: id, statuses: data.statuses, total: data.total, buyout });
             });
             result.push({ month, items });
         });


### PR DESCRIPTION
## Summary
- include total order count in buyout analytics response

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad498910a8832aa827d1336dbb97ac