### PR TITLE
feat: add generic async handler

### DIFF
--- a/src/shared/utils/asyncHandler.ts
+++ b/src/shared/utils/asyncHandler.ts
@@ -3,12 +3,16 @@ import { Request, Response, NextFunction, RequestHandler } from 'express';
 /**
  * Wraps an async route handler and forwards errors to the next middleware.
  */
-const asyncHandler = (
-    fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+const asyncHandler = <T>(
+    fn: (req: Request, res: Response, next: NextFunction) => Promise<T>
 ): RequestHandler => {
-    return (req, res, next) => {
-        Promise.resolve(fn(req, res, next)).catch(next);
-    };
+    const handler = (
+        req: Request,
+        res: Response,
+        next: NextFunction
+    ): Promise<T> => fn(req, res, next).catch(next) as Promise<T>;
+
+    return handler as unknown as RequestHandler;
 };
 
 export default asyncHandler;


### PR DESCRIPTION
## Summary
- refactor async handler to support generic return types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad4fb60a68832aae53ef3b8954635d