### PR TITLE
feat: add generic details to AppError

### DIFF
--- a/src/modules/posting/service/service.ts
+++ b/src/modules/posting/service/service.ts
@@ -53,7 +53,7 @@ export class PostingsService {
             }
         } catch (error) {
             logger.error({ err: error }, 'Failed to fetch postings');
-            throw new AppError('Failed to fetch postings', 502, error);
+            throw new AppError<unknown>('Failed to fetch postings', 502, error);
         }
 
         return postingsList ?? [];
@@ -66,7 +66,7 @@ export class PostingsService {
 
         if (!postingApi) {
             logger.warn({ postingNumber }, 'Posting not found');
-            throw new AppError('Posting not found', 404);
+            throw new AppError<undefined>('Posting not found', 404);
         }
 
         const posting: Partial<PostingDto> = {

--- a/src/modules/unit/controller/controller.ts
+++ b/src/modules/unit/controller/controller.ts
@@ -11,7 +11,7 @@ export const unitController = {
 
         const data = await unitService.getAll();
         if (data.length === 0) {
-            throw new AppError('Units not found', 404);
+            throw new AppError<undefined>('Units not found', 404);
         }
 
         res.json(data);
@@ -20,7 +20,7 @@ export const unitController = {
     async getAll(req: Request, res: Response): Promise<any> {
         const data = await unitService.getAll();
         if (data.length === 0) {
-            throw new AppError('Units not found', 404);
+            throw new AppError<undefined>('Units not found', 404);
         }
 
         res.json(data);

--- a/src/shared/types/AppError.ts
+++ b/src/shared/types/AppError.ts
@@ -1,8 +1,8 @@
-export class AppError extends Error {
+export class AppError<T = unknown> extends Error {
     public readonly statusCode: number;
-    public readonly details?: any;
+    public readonly details?: T;
 
-    constructor(message: string, statusCode: number, details?: any) {
+    constructor(message: string, statusCode: number, details?: T) {
         super(message);
         this.statusCode = statusCode;
         this.details = details;


### PR DESCRIPTION
## Summary
- add generic type for details in `AppError`
- specify detail types for all `AppError` instantiations

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4fb7e3d8832a80411053c2c0b132