### PR TITLE
refactor: type transaction fetch and clarify naming

### DIFF
--- a/src/modules/transaction/repository/fetch.api.ts
+++ b/src/modules/transaction/repository/fetch.api.ts
@@ -1,5 +1,5 @@
-import {sellerClient} from "@/infrastructure/clients/ozon/seller";
-import {ApiTransactionDto} from '@/modules/transaction/dto/api-transaction.dto';
+import { sellerClient } from "@/infrastructure/clients/ozon/seller";
+import { ApiTransactionDto } from '@/modules/transaction/dto/api-transaction.dto';
 
 export interface FilterParams {
     filter: {
@@ -11,10 +11,15 @@ export interface FilterParams {
     },
 }
 
-export async function fetch(params: FilterParams): Promise<ApiTransactionDto[]> {
+/**
+ * Fetches transactions from the Ozon API.
+ * The API is paginated; this function iterates through all pages
+ * and returns a consolidated array of ApiTransactionDto objects.
+ */
+export async function fetchTransactions(params: FilterParams): Promise<ApiTransactionDto[]> {
     const pageSize = 1000;
     let page = 1;
-    const allOperations: any[] = [];
+    const allOperations: ApiTransactionDto[] = [];
     const parseParams: FilterParams = {
         filter: {},
     };

--- a/src/modules/transaction/service/service.ts
+++ b/src/modules/transaction/service/service.ts
@@ -1,5 +1,4 @@
-import { fetch } from '@/modules/transaction/repository/fetch.api';
-import { FilterParams } from '@/modules/transaction/repository/fetch.api';
+import { fetchTransactions, FilterParams } from '@/modules/transaction/repository/fetch.api';
 import { TransactionDto } from '@/modules/transaction/dto/transaction.dto';
 import { logger } from '@/shared/logger';
 
@@ -9,7 +8,7 @@ export class TransactionService {
 
         let transactions: TransactionDto[] = [];
 
-        const transactionsQuery = await fetch({
+        const transactionsQuery = await fetchTransactions({
             ...params,
         });
 


### PR DESCRIPTION
## Summary
- type allOperations array as ApiTransactionDto
- rename fetch to fetchTransactions and add pagination JSDoc
- update transaction service imports

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4fbd41a8832aaa62963d009992c0