### PR TITLE
refactor: type-safe container maps

### DIFF
--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -12,8 +12,8 @@ type Token<T> = string | symbol | { new(...args: any[]): T };
 
 // Simple dependency injection container
 class Container {
-    private providers = new Map<Token<any>, () => any>();
-    private singletons = new Map<Token<any>, any>();
+    private providers = new Map<Token<unknown>, () => unknown>();
+    private singletons = new Map<Token<unknown>, unknown>();
 
     register<T>(token: Token<T>, provider: () => T): void {
         this.providers.set(token, provider);
@@ -21,7 +21,7 @@ class Container {
 
     resolve<T>(token: Token<T>): T {
         if (!this.singletons.has(token)) {
-            const provider = this.providers.get(token);
+            const provider = this.providers.get(token) as (() => T) | undefined;
             if (!provider) {
                 throw new Error(`No provider for token ${String(token)}`);
             }


### PR DESCRIPTION
## Summary
- tighten Container to track provider types without `any`
- cast resolved providers to requested types for safer retrieval

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4fbd4860832a9238b290a17cd3ad