### PR TITLE
feat: export units and ads for google sheets

### DIFF
--- a/src/modules/advertising/controller/controller.ts
+++ b/src/modules/advertising/controller/controller.ts
@@ -1,6 +1,8 @@
 import {Request, Response} from "express";
 import container from '@/infrastructure/di/container';
 import {AdvertisingService} from "@/modules/advertising/service/service";
+import { AppError } from "@/shared/types/AppError";
+import { toCsv } from "@/shared/utils/csv.utils";
 
 const advertisingService = container.resolve(AdvertisingService);
 
@@ -9,5 +11,15 @@ export const advertisingController = {
         await advertisingService.sync();
 
         res.json({data: 'OK'});
+    },
+
+    async importData(req: Request, res: Response) {
+        const data = await advertisingService.getAll();
+        if (data.length === 0) {
+            throw new AppError<undefined>('Ads not found', 404);
+        }
+
+        const csv = toCsv(data as any[]);
+        res.header('Content-Type', 'text/csv').send(csv);
     },
 };

--- a/src/modules/advertising/repository/repository.ts
+++ b/src/modules/advertising/repository/repository.ts
@@ -59,6 +59,14 @@ export class AdvertisingRepository {
         });
     }
 
+    async getAll(): Promise<Advertising[]> {
+        return this.prismaClient.advertising.findMany({
+            orderBy: {
+                savedAt: 'desc',
+            },
+        });
+    }
+
     async getAdsAggByProductType(start: string, end: string): Promise<{ items: AdItem[]; totals: number }> {
         const totals = await this.prismaClient.advertising.groupBy({
             by: [

--- a/src/modules/advertising/route.ts
+++ b/src/modules/advertising/route.ts
@@ -4,5 +4,6 @@ import asyncHandler from '@/shared/utils/asyncHandler';
 
 const router = Router();
 router.get('/sync', asyncHandler(advertisingController.sync));
+router.get('/importdata', asyncHandler(advertisingController.importData));
 
 export default router;

--- a/src/modules/advertising/service/service.ts
+++ b/src/modules/advertising/service/service.ts
@@ -59,6 +59,10 @@ export class AdvertisingService {
     constructor(private adsRepo: AdvertisingRepository) {
     }
 
+    async getAll() {
+        return this.adsRepo.getAll();
+    }
+
     async buildCompany(campaign: CampaignStats): Promise<CampaignReport | null> {
         try {
             const clicks = toDecimal(campaign.clicks);

--- a/src/modules/unit/controller/controller.ts
+++ b/src/modules/unit/controller/controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import container from '@/infrastructure/di/container';
 import { UnitService } from "@/modules/unit/service/service";
 import { AppError } from "@/shared/types/AppError";
+import { toCsv } from "@/shared/utils/csv.utils";
 
 const unitService = container.resolve(UnitService);
 
@@ -24,5 +25,15 @@ export const unitController = {
         }
 
         res.json(data);
+    },
+
+    async importData(req: Request, res: Response): Promise<void> {
+        const data = await unitService.getAll();
+        if (data.length === 0) {
+            throw new AppError<undefined>('Units not found', 404);
+        }
+
+        const csv = toCsv(data as any[]);
+        res.header('Content-Type', 'text/csv').send(csv);
     },
 };

--- a/src/modules/unit/route.ts
+++ b/src/modules/unit/route.ts
@@ -6,5 +6,6 @@ const router = Router();
 
 router.get('/sync', asyncHandler(unitController.sync));
 router.get('/all', asyncHandler(unitController.getAll));
+router.get('/importdata', asyncHandler(unitController.importData));
 
 export default router;

--- a/src/shared/utils/csv.utils.ts
+++ b/src/shared/utils/csv.utils.ts
@@ -1,0 +1,22 @@
+export const toCsv = (rows: Record<string, unknown>[]): string => {
+    if (rows.length === 0) {
+        return '';
+    }
+
+    const headers = Object.keys(rows[0]);
+
+    const escape = (val: unknown): string => {
+        if (val === null || val === undefined) {
+            return '';
+        }
+
+        const str = val instanceof Date ? val.toISOString() : String(val);
+        const escaped = str.replace(/"/g, '""');
+        return /[",\n]/.test(escaped) ? `"${escaped}"` : escaped;
+    };
+
+    const data = rows.map((row) => headers.map((h) => escape((row as any)[h])).join(','));
+    return [headers.join(','), ...data].join('\n');
+};
+
+export default toCsv;


### PR DESCRIPTION
## Summary
- add utility for converting query results to CSV
- expose /unit/importdata and /ads/importdata endpoints serving CSV for Google Sheets
- include repository and service helpers to fetch advertising data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adaff52388832a8cf70990e372eb63