### PR TITLE
feat: add units import for google sheets

### DIFF
--- a/src/modules/unit/controller/controller.ts
+++ b/src/modules/unit/controller/controller.ts
@@ -28,7 +28,7 @@ export const unitController = {
     },
 
     async importData(req: Request, res: Response): Promise<void> {
-        const data = await unitService.getAll();
+        const data = await unitService.getImportData();
         if (data.length === 0) {
             throw new AppError<undefined>('Units not found', 404);
         }

--- a/src/modules/unit/service/service.ts
+++ b/src/modules/unit/service/service.ts
@@ -238,4 +238,36 @@ export class UnitService {
     async getAll() {
         return await this.unitRepo.getAll();
     }
+
+    /**
+     * Prepares unit data for Google Sheets import.
+     * Converts numeric monetary fields from cents to rubles and flattens
+     * nested structures for CSV serialization.
+     *
+     * @returns {Promise<Record<string, unknown>[]>} Array of plain objects
+     * suitable for CSV export.
+     */
+    async getImportData() {
+        const units = await this.unitRepo.getAll();
+
+        return units.map((u) => ({
+            postingNumber: u.postingNumber,
+            product: u.product,
+            sku: u.sku,
+            status: u.status,
+            createdAt: u.createdAt.toISOString(),
+            lastOperationDate: u.lastOperationDate
+                ? u.lastOperationDate.toISOString()
+                : '',
+            price: Number(u.price) / 100,
+            costPrice: Number(u.costPrice) / 100,
+            totalServices: Number(u.totalServices) / 100,
+            margin: Number(u.margin) / 100,
+            services: Array.isArray(u.services)
+                ? (u.services as any[])
+                    .map((s) => `${s.name}:${s.price}`)
+                    .join(';')
+                : '',
+        }));
+    }
 }


### PR DESCRIPTION
## Summary
- format unit data for Google Sheets import by converting cents to rubles and flattening service details
- expose formatted units through `/units/importdata`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc5fa20c8832a9cf0cb14f0b832f0