### PR TITLE
feat: add hourly advertising sync

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,29 @@ model Advertising {
   @@unique([savedAt, campaignId])
 }
 
+model AdvertisingHourly {
+  id           String   @id @default(uuid())
+  campaignId   String
+  productId    String
+  type         String
+  moneySpent   Float
+  views        Int
+  clicks       Int
+  toCart       Int
+  ctr          Float
+  weeklyBudget Int
+  status       String
+  avgBid       Float
+  crToCart     Float
+  costPerCart  Float
+  savedAt      DateTime
+  updatedAt    DateTime
+  orders       Int
+  ordersMoney  Float
+
+  @@unique([updatedAt, campaignId])
+}
+
 model UnitNew {
   id                   String    @id @default(cuid())
   product              String

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,13 @@ import '@/infrastructure/di/container';
 import unitRouter from "@/modules/unit/route";
 import advertisingRouter from "@/modules/advertising/route";
 import analyticsRouter from "@/modules/analytics/route";
+import advertisingHourlyRouter from '@/modules/advertising-hourly/route';
 import cors from "cors";
 import { PORT, CORS_ORIGIN } from '@/config';
 import errorHandler from "@/shared/middleware/errorHandler";
 import { logger } from '@/shared/logger';
 import '@/bot';
+import '@/modules/advertising-hourly/cron';
 
 const app = express();
 
@@ -19,6 +21,7 @@ app.use(cors({
 
 app.use('/unit', unitRouter);
 app.use('/ads', advertisingRouter);
+app.use('/ads-hourly', advertisingHourlyRouter);
 app.use("/analytics", analyticsRouter);
 
 app.use(errorHandler);

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -2,6 +2,8 @@ import {sellerClient} from '@/infrastructure/clients/ozon/seller';
 import {performanceClient} from '@/infrastructure/clients/ozon/performance';
 import {AdvertisingRepository} from '@/modules/advertising/repository/repository';
 import {AdvertisingService} from '@/modules/advertising/service/service';
+import {AdvertisingHourlyRepository} from '@/modules/advertising-hourly/repository/repository';
+import {AdvertisingHourlyService} from '@/modules/advertising-hourly/service/service';
 import {AnalyticsService} from '@/modules/analytics/service/service';
 import {UnitRepository} from '@/modules/unit/repository/repository';
 import {PostingsService} from '@/modules/posting/service/service';
@@ -40,10 +42,15 @@ container.register('performanceClient', () => performanceClient);
 // Repositories
 container.register(AdvertisingRepository, () => new AdvertisingRepository());
 container.register(UnitRepository, () => new UnitRepository());
+container.register(AdvertisingHourlyRepository, () => new AdvertisingHourlyRepository());
 
 // Services
 container.register(AdvertisingService, () => new AdvertisingService(
     container.resolve(AdvertisingRepository),
+));
+container.register(AdvertisingHourlyService, () => new AdvertisingHourlyService(
+    container.resolve(AdvertisingService),
+    container.resolve(AdvertisingHourlyRepository),
 ));
 
 container.register(PostingsService, () => new PostingsService());

--- a/src/modules/advertising-hourly/controller/controller.ts
+++ b/src/modules/advertising-hourly/controller/controller.ts
@@ -1,0 +1,16 @@
+import {Request, Response} from 'express';
+import container from '@/infrastructure/di/container';
+import {AdvertisingHourlyService} from '@/modules/advertising-hourly/service/service';
+import {AppError} from '@/shared/types/AppError';
+
+const service = container.resolve(AdvertisingHourlyService);
+
+export const advertisingHourlyController = {
+    async getAll(req: Request, res: Response) {
+        const data = await service.getAll();
+        if (data.length === 0) {
+            throw new AppError<undefined>('Ads not found', 404);
+        }
+        res.json(data);
+    },
+};

--- a/src/modules/advertising-hourly/cron.ts
+++ b/src/modules/advertising-hourly/cron.ts
@@ -1,0 +1,19 @@
+import container from '@/infrastructure/di/container';
+import {AdvertisingHourlyService} from '@/modules/advertising-hourly/service/service';
+import {logger} from '@/shared/logger';
+
+const service = container.resolve(AdvertisingHourlyService);
+
+const FOUR_HOURS = 4 * 60 * 60 * 1000;
+
+const run = async () => {
+    try {
+        await service.sync();
+        logger.info('✅ Hourly advertising snapshot saved');
+    } catch (error) {
+        logger.error({err: error}, '❌ Failed to save hourly advertising snapshot');
+    }
+};
+
+run();
+setInterval(run, FOUR_HOURS);

--- a/src/modules/advertising-hourly/repository/repository.ts
+++ b/src/modules/advertising-hourly/repository/repository.ts
@@ -1,0 +1,61 @@
+import {PrismaClient, AdvertisingHourly} from '@prisma/client';
+import prisma from '@/infrastructure/database/prismaClient';
+
+export class AdvertisingHourlyRepository {
+    constructor(private prismaClient: PrismaClient = prisma) {}
+
+    async create(campaign: any): Promise<AdvertisingHourly> {
+        const now = new Date();
+
+        return this.prismaClient.advertisingHourly.upsert({
+            where: {
+                updatedAt_campaignId: {
+                    updatedAt: now,
+                    campaignId: String(campaign.id),
+                },
+            },
+            update: {
+                productId: String(campaign.sku),
+                type: campaign.type,
+                moneySpent: campaign.moneySpent,
+                views: campaign.views,
+                clicks: campaign.clicks,
+                toCart: campaign.toCart,
+                ctr: campaign.ctr,
+                weeklyBudget: campaign.weeklyBudget,
+                status: campaign.status ? campaign.status : '',
+                avgBid: campaign.avgBid,
+                crToCart: campaign.crToCart,
+                costPerCart: campaign.costPerCart,
+                orders: campaign.orders,
+                ordersMoney: campaign.ordersMoney,
+                savedAt: now,
+            },
+            create: {
+                campaignId: String(campaign.id),
+                productId: String(campaign.sku),
+                type: campaign.type,
+                moneySpent: campaign.moneySpent,
+                views: campaign.views,
+                clicks: campaign.clicks,
+                toCart: campaign.toCart,
+                ctr: campaign.ctr,
+                weeklyBudget: campaign.weeklyBudget,
+                status: campaign.status ? campaign.status : '',
+                avgBid: campaign.avgBid,
+                crToCart: campaign.crToCart,
+                costPerCart: campaign.costPerCart,
+                orders: campaign.orders,
+                ordersMoney: campaign.ordersMoney,
+                savedAt: now,
+                updatedAt: now,
+            },
+        });
+    }
+
+    async getAll(): Promise<AdvertisingHourly[]> {
+        return this.prismaClient.advertisingHourly.findMany({
+            orderBy: { updatedAt: 'desc' },
+        });
+    }
+}

--- a/src/modules/advertising-hourly/route.ts
+++ b/src/modules/advertising-hourly/route.ts
@@ -1,0 +1,8 @@
+import {Router} from 'express';
+import {advertisingHourlyController} from '@/modules/advertising-hourly/controller/controller';
+import asyncHandler from '@/shared/utils/asyncHandler';
+
+const router = Router();
+router.get('/', asyncHandler(advertisingHourlyController.getAll));
+
+export default router;

--- a/src/modules/advertising-hourly/service/service.ts
+++ b/src/modules/advertising-hourly/service/service.ts
@@ -1,0 +1,24 @@
+import {AdvertisingService} from '@/modules/advertising/service/service';
+import {AdvertisingHourlyRepository} from '@/modules/advertising-hourly/repository/repository';
+import dayjs from 'dayjs';
+
+export class AdvertisingHourlyService {
+    constructor(
+        private adsService: AdvertisingService,
+        private hourlyRepo: AdvertisingHourlyRepository,
+    ) {}
+
+    async sync() {
+        const date = dayjs().format('YYYY-MM-DD');
+        const campaigns = await this.adsService.fetchPpcCampaigns(date);
+
+        for (const campaign of campaigns) {
+            const campaignBuild = await this.adsService.buildCompany(campaign);
+            await this.hourlyRepo.create(campaignBuild);
+        }
+    }
+
+    async getAll() {
+        return this.hourlyRepo.getAll();
+    }
+}


### PR DESCRIPTION
## Summary
- add AdvertisingHourly table with updatedAt
- schedule periodic snapshot saving every 4 hours
- expose endpoint to list hourly advertising data

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade032a294832ab49e7ead528e45a9