### PR TITLE
Send daily ads CSV in cron notification

### DIFF
--- a/src/modules/advertising-hourly/cron.ts
+++ b/src/modules/advertising-hourly/cron.ts
@@ -3,6 +3,7 @@ import {AdvertisingHourlyService} from '@/modules/advertising-hourly/service/ser
 import {logger} from '@/shared/logger';
 import {Telegraf} from 'telegraf';
 import {BOT_TOKEN, CRON_CHAT_ID} from '@/config';
+import dayjs from 'dayjs';
 
 const service = container.resolve(AdvertisingHourlyService);
 const telegram = new Telegraf(BOT_TOKEN).telegram;
@@ -15,6 +16,31 @@ const notify = async (text: string): Promise<void> => {
     }
 };
 
+const sendCsv = async (): Promise<void> => {
+    try {
+        const date = dayjs().format('YYYY-MM-DD');
+        const rows = await service.getByDate(date);
+        if (!rows.length) return;
+
+        const headers = [
+            'campaignId','productId','type','moneySpent','views','clicks','toCart','ctr','weeklyBudget','status','avgBid','crToCart','costPerCart','orders','ordersMoney','savedAt','updatedAt'
+        ];
+
+        const csvRows = [headers.join(',')];
+        for (const row of rows) {
+            csvRows.push(headers.map((h) => String((row as any)[h] ?? '')).join(','));
+        }
+
+        const csv = csvRows.join('\n');
+        await telegram.sendDocument(CRON_CHAT_ID, {
+            source: Buffer.from(csv),
+            filename: `ads-${date}.csv`,
+        });
+    } catch (err) {
+        logger.error({err}, 'Failed to send CSV report');
+    }
+};
+
 const FIVE_MINUTES = 2 * 60 * 1000;
 
 const run = async () => {
@@ -22,6 +48,7 @@ const run = async () => {
         await service.sync();
         logger.info('✅ Hourly advertising snapshot saved');
         await notify('✅ Hourly advertising snapshot saved');
+        await sendCsv();
     } catch (error) {
         logger.error({err: error}, '❌ Failed to save hourly advertising snapshot');
         await notify('❌ Failed to save hourly advertising snapshot');

--- a/src/modules/advertising-hourly/repository/repository.ts
+++ b/src/modules/advertising-hourly/repository/repository.ts
@@ -69,4 +69,22 @@ export class AdvertisingHourlyRepository {
             orderBy: {updatedAt: 'desc'},
         });
     }
+
+    async getByDate(date: string): Promise<AdvertisingHourly[]> {
+        const start = dayjs.tz(date, "Asia/Yerevan").startOf('day');
+        const end = dayjs.tz(date, "Asia/Yerevan").endOf('day');
+
+        const from = dayjs.utc(start.format("YYYY-MM-DDTHH:mm:ss.SSS"));
+        const to = dayjs.utc(end.format("YYYY-MM-DDTHH:mm:ss.SSS"));
+
+        return this.prismaClient.advertisingHourly.findMany({
+            where: {
+                updatedAt: {
+                    gte: from.toDate(),
+                    lte: to.toDate(),
+                },
+            },
+            orderBy: {updatedAt: 'desc'},
+        });
+    }
 }

--- a/src/modules/advertising-hourly/service/service.ts
+++ b/src/modules/advertising-hourly/service/service.ts
@@ -21,4 +21,8 @@ export class AdvertisingHourlyService {
     async getAll() {
         return this.hourlyRepo.getAll();
     }
+
+    async getByDate(date: string) {
+        return this.hourlyRepo.getByDate(date);
+    }
 }


### PR DESCRIPTION
## Summary
- send CSV report with daily advertising data after cron sync
- add repository and service helpers to fetch entries for a specific date

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adfbf764e8832a9d6179324cb690ed