### PR TITLE
Throttle Ozon API calls to avoid 429 errors

### DIFF
--- a/src/infrastructure/clients/ozon/seller.ts
+++ b/src/infrastructure/clients/ozon/seller.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { SELLER_CLIENT_ID, SELLER_API_KEY } from '@/config';
+import { waitRateLimit } from '@/shared/utils/rateLimit';
 
 export const sellerClient = axios.create({
     baseURL: 'https://api-seller.ozon.ru',
@@ -8,4 +9,9 @@ export const sellerClient = axios.create({
         'Client-Id': SELLER_CLIENT_ID,
         'Api-Key': SELLER_API_KEY,
     }
+});
+
+sellerClient.interceptors.request.use(async config => {
+    await waitRateLimit();
+    return config;
 });

--- a/src/shared/utils/rateLimit.ts
+++ b/src/shared/utils/rateLimit.ts
@@ -1,0 +1,11 @@
+let lastRequestTime = 0;
+const MIN_INTERVAL_MS = 1000;
+
+export const waitRateLimit = async (): Promise<void> => {
+    const now = Date.now();
+    const diff = now - lastRequestTime;
+    if (diff < MIN_INTERVAL_MS) {
+        await new Promise(resolve => setTimeout(resolve, MIN_INTERVAL_MS - diff));
+    }
+    lastRequestTime = Date.now();
+};


### PR DESCRIPTION
## Summary
- add shared rate limiter utility
- delay Ozon API client requests to reduce 429 errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2c1b02efc832a90b935005e6d5d97