### PR TITLE
feat: add transaction sync

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,3 +75,21 @@ model UnitNew {
 
   @@unique([postingNumber])
 }
+
+model Transaction {
+  id                String   @id @default(cuid())
+  operationId       Int      @unique
+  operationType     String
+  operationDate     DateTime
+  operationTypeName String
+  deliveryCharge        Float
+  returnDeliveryCharge  Float
+  accrualsForSale       Float
+  saleCommission        Float
+  amount            Float
+  type              String
+  postingNumber     String?
+  items             Json
+  services          Json
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import '@/infrastructure/di/container';
 import unitRouter from "@/modules/unit/route";
 import advertisingRouter from "@/modules/advertising/route";
 import analyticsRouter from "@/modules/analytics/route";
+import transactionRouter from "@/modules/transaction/route";
 import cors from "cors";
 import { PORT, CORS_ORIGIN } from '@/config';
 import errorHandler from "@/shared/middleware/errorHandler";
@@ -20,6 +21,7 @@ app.use(cors({
 app.use('/unit', unitRouter);
 app.use('/ads', advertisingRouter);
 app.use("/analytics", analyticsRouter);
+app.use('/transactions', transactionRouter);
 
 app.use(errorHandler);
 

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -6,6 +6,7 @@ import {AnalyticsService} from '@/modules/analytics/service/service';
 import {UnitRepository} from '@/modules/unit/repository/repository';
 import {PostingsService} from '@/modules/posting/service/service';
 import {TransactionService} from '@/modules/transaction/service/service';
+import {TransactionRepository} from '@/modules/transaction/repository/repository';
 import {UnitService} from '@/modules/unit/service/service';
 
 type Token<T> = string | symbol | { new(...args: any[]): T };
@@ -40,6 +41,7 @@ container.register('performanceClient', () => performanceClient);
 // Repositories
 container.register(AdvertisingRepository, () => new AdvertisingRepository());
 container.register(UnitRepository, () => new UnitRepository());
+container.register(TransactionRepository, () => new TransactionRepository());
 
 // Services
 container.register(AdvertisingService, () => new AdvertisingService(
@@ -47,7 +49,9 @@ container.register(AdvertisingService, () => new AdvertisingService(
 ));
 
 container.register(PostingsService, () => new PostingsService());
-container.register(TransactionService, () => new TransactionService());
+container.register(TransactionService, () => new TransactionService(
+    container.resolve(TransactionRepository),
+));
 
 container.register(UnitService, () => new UnitService(
     container.resolve(UnitRepository),

--- a/src/modules/transaction/controller/controller.ts
+++ b/src/modules/transaction/controller/controller.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+import container from '@/infrastructure/di/container';
+import { TransactionService } from '@/modules/transaction/service/service';
+
+const transactionService = container.resolve(TransactionService);
+
+export const transactionController = {
+    async sync(req: Request, res: Response): Promise<void> {
+        await transactionService.sync();
+        res.json({ data: 'OK' });
+    },
+};
+

--- a/src/modules/transaction/repository/repository.ts
+++ b/src/modules/transaction/repository/repository.ts
@@ -1,0 +1,54 @@
+import { PrismaClient, Transaction } from '@prisma/client';
+import prisma from '@/infrastructure/database/prismaClient';
+import { ApiTransactionDto } from '@/modules/transaction/dto/api-transaction.dto';
+import { Prisma } from '@prisma/client';
+
+export class TransactionRepository {
+    constructor(private prismaClient: PrismaClient = prisma) {}
+
+    async create(data: ApiTransactionDto): Promise<Transaction> {
+        return this.prismaClient.transaction.upsert({
+            where: { operationId: data.operation_id },
+            create: {
+                operationId: data.operation_id,
+                operationType: data.operation_type,
+                operationDate: new Date(data.operation_date),
+                operationTypeName: data.operation_type_name,
+                deliveryCharge: data.delivery_charge,
+                returnDeliveryCharge: data.return_delivery_charge,
+                accrualsForSale: data.accruals_for_sale,
+                saleCommission: data.sale_commission,
+                amount: data.amount,
+                type: data.type,
+                postingNumber: data.posting?.posting_number ?? null,
+                items: data.items as Prisma.InputJsonValue,
+                services: data.services as Prisma.InputJsonValue,
+            },
+            update: {
+                operationType: data.operation_type,
+                operationDate: new Date(data.operation_date),
+                operationTypeName: data.operation_type_name,
+                deliveryCharge: data.delivery_charge,
+                returnDeliveryCharge: data.return_delivery_charge,
+                accrualsForSale: data.accruals_for_sale,
+                saleCommission: data.sale_commission,
+                amount: data.amount,
+                type: data.type,
+                postingNumber: data.posting?.posting_number ?? null,
+                items: data.items as Prisma.InputJsonValue,
+                services: data.services as Prisma.InputJsonValue,
+            },
+        });
+    }
+
+    async saveMany(data: ApiTransactionDto[]): Promise<Transaction[]> {
+        return Promise.all(data.map(d => this.create(d)));
+    }
+
+    async lastRow(): Promise<Transaction | null> {
+        return this.prismaClient.transaction.findFirst({
+            orderBy: { operationDate: 'desc' },
+        });
+    }
+}
+

--- a/src/modules/transaction/route.ts
+++ b/src/modules/transaction/route.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { transactionController } from '@/modules/transaction/controller/controller';
+import asyncHandler from '@/shared/utils/asyncHandler';
+
+const router = Router();
+
+router.get('/sync', asyncHandler(transactionController.sync));
+
+export default router;
+

--- a/src/modules/transaction/service/service.ts
+++ b/src/modules/transaction/service/service.ts
@@ -1,8 +1,13 @@
+import dayjs from 'dayjs';
 import { fetchTransactions, FilterParams } from '@/modules/transaction/repository/fetch.api';
 import { TransactionDto } from '@/modules/transaction/dto/transaction.dto';
 import { logger } from '@/shared/logger';
+import { TransactionRepository } from '@/modules/transaction/repository/repository';
+import { ApiTransactionDto } from '@/modules/transaction/dto/api-transaction.dto';
 
 export class TransactionService {
+    constructor(private txRepo: TransactionRepository = new TransactionRepository()) {}
+
     async get(params: FilterParams): Promise<TransactionDto[]> {
         logger.info({ params }, 'Fetching transactions');
 
@@ -21,7 +26,6 @@ export class TransactionService {
                 items: t.items,
             });
         }
-
 
         return transactions;
     }
@@ -44,6 +48,55 @@ export class TransactionService {
             transactions.push(...(t ?? []));
         }
 
-        return transactions
+        return transactions;
+    }
+
+    private buildMonthRanges(from: dayjs.Dayjs, to: dayjs.Dayjs): { from: string; to: string }[] {
+        const ranges: { from: string; to: string }[] = [];
+        let start = from.startOf('month');
+        const end = to.endOf('month');
+
+        while (start.isBefore(end) || start.isSame(end, 'month')) {
+            let rangeStart = start;
+            let rangeEnd = start.endOf('month');
+
+            if (rangeStart.isBefore(from)) {
+                rangeStart = from;
+            }
+            if (rangeEnd.isAfter(to)) {
+                rangeEnd = to;
+            }
+
+            ranges.push({
+                from: rangeStart.format('YYYY-MM-DD') + 'T00:00:00Z',
+                to: rangeEnd.format('YYYY-MM-DD') + 'T23:59:59Z',
+            });
+
+            start = start.add(1, 'month');
+        }
+
+        return ranges;
+    }
+
+    async sync(): Promise<void> {
+        const last = await this.txRepo.lastRow();
+        const from = last ? dayjs(last.operationDate) : dayjs('2024-10-01');
+        const to = dayjs();
+        const ranges = this.buildMonthRanges(from, to);
+
+        for (const { from: f, to: t } of ranges) {
+            const txs = await fetchTransactions({
+                filter: {
+                    date: { from: f, to: t },
+                },
+            });
+
+            const filtered = txs.filter(tx => !tx.posting?.posting_number);
+
+            if (filtered.length > 0) {
+                await this.txRepo.saveMany(filtered as ApiTransactionDto[]);
+            }
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- add Transaction prisma model and repository
- sync and store monthly transactions without posting number
- expose `/transactions/sync` endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b455abea1c832a84998d9e88b3ee64