### PR TITLE
feat: include ads cost in unit response

### DIFF
--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -53,6 +53,7 @@ container.register(UnitService, () => new UnitService(
     container.resolve(UnitRepository),
     container.resolve(PostingsService),
     container.resolve(TransactionService),
+    container.resolve(AdvertisingRepository),
 ));
 
 container.register(AnalyticsService, () => new AnalyticsService(


### PR DESCRIPTION
## Summary
- add ads spend calculation per SKU to /uni/getall
- subtract advertising cost from margin

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d2ebcd84832aa3e126d59400158c