### PR TITLE
feat: add filters for unit getall

### DIFF
--- a/src/modules/unit/repository/repository.ts
+++ b/src/modules/unit/repository/repository.ts
@@ -90,11 +90,12 @@ export class UnitRepository {
         });
     }
 
-    async getAll(): Promise<UnitNew[]> {
+    async getAll(filter: Prisma.UnitNewWhereInput = {}): Promise<UnitNew[]> {
         return this.prismaClient.unitNew.findMany({
+            where: filter,
             orderBy: {
                 createdAt: 'desc',
-            }
+            },
         });
     }
 

--- a/src/modules/unit/service/service.ts
+++ b/src/modules/unit/service/service.ts
@@ -9,6 +9,7 @@ import {TransactionDto} from '@/modules/transaction/dto/transaction.dto';
 import {UnitRepository} from '@/modules/unit/repository/repository';
 import {PostingDto} from '@/modules/posting/dto/posting.dto';
 import {logger} from '@/shared/logger';
+import {Prisma} from '@prisma/client';
 
 dayjs.extend(minMax);
 
@@ -229,8 +230,8 @@ export class UnitService {
         await this.combinePostingsAndTransactions();
     }
 
-    async getAll() {
-        const data = await this.unitRepo.getAll();
+    async getAll(filter: Prisma.UnitNewWhereInput = {}) {
+        const data = await this.unitRepo.getAll(filter);
 
         const monthSkuCount = new Map<string, Map<string, number>>();
         const months = new Set<string>();


### PR DESCRIPTION
## Summary
- allow getAll to filter units using query parameters
- plumb filters through service and repository

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b68130ad44832abf0f6fe48e304ba8